### PR TITLE
Update Cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
-cryptography==42.0.8
+cryptography==44.0.0
 idna==3.7
 jwt==1.3.1
 pycparser==2.22


### PR DESCRIPTION
Update Cryptography to version 44.0.0 to address [GHSA-h4gh-qq45-vh27](https://github.com/advisories/GHSA-h4gh-qq45-vh27).